### PR TITLE
Periodically sync ssl certificates if changed

### DIFF
--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -2111,6 +2111,8 @@ ngx_stream_proxy_collect_server(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *psc
       return NGX_ERROR;
     }
 
+    *pscfp = pscf;
+
     return NGX_OK;
 }
 

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -1989,7 +1989,7 @@ ngx_stream_proxy_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_ptr_value(conf->ssl_passwords, prev->ssl_passwords, NULL);
 
-    if (conf->ssl_enable && ngx_stream_proxy_set_ssl(cf, conf) != NGX_OK) {
+    if (conf->ssl_enable && ngx_stream_proxy_set_ssl(cf, conf, 0) != NGX_OK) {
         return NGX_CONF_ERROR;
     }
 

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -1997,6 +1997,7 @@ static ngx_int_t
 ngx_stream_proxy_set_ssl(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf)
 {
     ngx_pool_cleanup_t  *cln;
+    ngx_file_info_t     fi;
 
     pscf->ssl = ngx_pcalloc(cf->pool, sizeof(ngx_ssl_t));
     if (pscf->ssl == NULL) {
@@ -2031,6 +2032,20 @@ ngx_stream_proxy_set_ssl(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf)
             != NGX_OK)
         {
             return NGX_ERROR;
+        }
+
+        if (pscf->ssl_sync_enable) {
+            if (ngx_file_info((const char *) pscf->ssl_certificate.data, &fi) == NGX_FILE_ERROR) {
+                return NGX_ERROR;
+            }
+
+            pscf->ssl_certificate_mtime = fi.st_mtime;
+
+            if (ngx_file_info((const char *) pscf->ssl_certificate_key.data, &fi) == NGX_FILE_ERROR) {
+                return NGX_ERROR;
+            }
+
+            pscf->ssl_certificate_key_mtime = fi.st_mtime;
         }
     }
 

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -1035,6 +1035,11 @@ ngx_stream_proxy_ssl_init_connection(ngx_stream_session_t *s)
 
     pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
 
+    if (pscf->new_ssl != NULL) {
+      *pscf->ssl = *pscf->new_ssl;
+      ngx_free(pscf->new_ssl);
+    }
+
     if (ngx_ssl_create_connection(pscf->ssl, pc, NGX_SSL_BUFFER|NGX_SSL_CLIENT)
         != NGX_OK)
     {

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -259,7 +259,7 @@ static ngx_command_t  ngx_stream_proxy_commands[] = {
       NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_msec_slot,
       NGX_STREAM_SRV_CONF_OFFSET,
-      offsetof(ngx_stream_ssl_sync_srv_conf_t, ssl_sync_interval),
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_sync_interval),
       NULL },
 
     { ngx_string("proxy_ssl_session_reuse"),
@@ -1856,7 +1856,7 @@ ngx_stream_proxy_create_main_conf(ngx_conf_t *cf)
         return NULL;
     }
 
-    return conf
+    return conf;
 }
 
 
@@ -2101,7 +2101,7 @@ ngx_stream_proxy_set_ssl(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf, ngx_
 static ngx_int_t
 ngx_stream_proxy_collect_server(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf)
 {
-    ngx_stream_ssl_sync_main_conf_t  *pmcf;
+    ngx_stream_proxy_main_conf_t     *pmcf;
     ngx_stream_proxy_srv_conf_t      **pscfp;
 
     pmcf = ngx_stream_conf_get_module_main_conf(cf, ngx_stream_proxy_module);
@@ -2118,9 +2118,9 @@ ngx_stream_proxy_collect_server(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *psc
 static void
 ngx_stream_proxy_ssl_sync_handler(ngx_event_t *ev)
 {
-    ngx_stream_proxy_srv_conf_t  *pscf = ev.data;
+    ngx_stream_proxy_srv_conf_t  *pscf = ev->data;
     ngx_file_info_t              fi;
-    time_t                       new_ssl_certificate_mtime
+    time_t                       new_ssl_certificate_mtime;
     time_t                       new_ssl_certificate_key_mtime;
 
     if (ngx_file_info((const char *) pscf->ssl_certificate.data, &fi) == NGX_FILE_ERROR) {
@@ -2138,7 +2138,7 @@ ngx_stream_proxy_ssl_sync_handler(ngx_event_t *ev)
     if (new_ssl_certificate_mtime != pscf->ssl_certificate_mtime ||
         new_ssl_certificate_key_mtime != pscf->ssl_certificate_key_mtime)
     {
-        ngx_stream_proxy_set_ssl(pscf->cf, pscf, 1)
+        ngx_stream_proxy_set_ssl(pscf->cf, pscf, 1);
     }
 
     ngx_add_timer(ev, pscf->ssl_sync_interval);
@@ -2148,7 +2148,7 @@ ngx_stream_proxy_ssl_sync_handler(ngx_event_t *ev)
 
 
 static ngx_int_t
-ngx_stream_proxy_init_process(ngx_conf_t *cycle)
+ngx_stream_proxy_init_process(ngx_cycle_t *cycle)
 {
 
 #if (NGX_STREAM_SSL)
@@ -2156,7 +2156,7 @@ ngx_stream_proxy_init_process(ngx_conf_t *cycle)
     ngx_stream_proxy_main_conf_t  *pmcf;
     ngx_stream_proxy_srv_conf_t  	**pscfp;
 
-    pmcf = ngx_stream_cycle_get_module_main_conf(cycle, ngx_stream_ssl_sync_module);
+    pmcf = ngx_stream_cycle_get_module_main_conf(cycle, ngx_stream_proxy_module);
 
     pscfp = pmcf->servers.elts;
 

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -106,6 +106,8 @@ static void ngx_stream_proxy_ssl_handshake(ngx_connection_t *pc);
 static ngx_int_t ngx_stream_proxy_ssl_name(ngx_stream_session_t *s);
 static ngx_int_t ngx_stream_proxy_set_ssl(ngx_conf_t *cf,
     ngx_stream_proxy_srv_conf_t *pscf);
+static ngx_int_t ngx_stream_proxy_collect_server(ngx_conf_t *cf,
+    ngx_stream_proxy_srv_conf_t *pscf);
 
 
 static ngx_conf_bitmask_t  ngx_stream_proxy_ssl_protocols[] = {
@@ -1979,6 +1981,10 @@ ngx_stream_proxy_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
         return NGX_CONF_ERROR;
     }
 
+    if (conf->ssl_sync_enable && ngx_stream_proxy_collect_server(cf, conf) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
 #endif
 
     return NGX_CONF_OK;
@@ -2050,6 +2056,23 @@ ngx_stream_proxy_set_ssl(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf)
         if (ngx_ssl_crl(cf, pscf->ssl, &pscf->ssl_crl) != NGX_OK) {
             return NGX_ERROR;
         }
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_stream_proxy_collect_server(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf)
+{
+    ngx_stream_ssl_sync_main_conf_t  *pmcf;
+    ngx_stream_proxy_srv_conf_t      **pscfp;
+
+    pmcf = ngx_stream_conf_get_module_main_conf(cf, ngx_stream_proxy_module);
+
+    pscfp = ngx_array_push(&pmcf->servers);
+    if (pscfp == NULL) {
+      return NGX_ERROR;
     }
 
     return NGX_OK;


### PR DESCRIPTION
This is a _scrappy_ implementation of periodically checking certificate files and re-reading them for new SSL connection initiation if there is any change. It can be useful with ephemeral client certificates where they change frequently. Using something like this we can avoid reloading Nginx every time client certificate changes. By not reloading Nginx we make sure existing connections don't get torn down.

_Note_ that this is just a proof of concept and a task for me to get to play with Nginx internals in order to understanding them better. I'm sure there are a lot of room for improvements. _I'd really appreciate if I can get some experienced Nginx module developer to give some feedback_. Later on I'm planning to extract this out into a separate Nginx module, because I don't think this feature should be part of `ngx_stream_proxy_module`, I did it as a patch to it in this PR only because it was easier to get started this way.

The patch introduces `proxy_ssl_sync_enable` and `ssl_sync_interval` directives to be used in main and server configuration sections. `proxy_ssl_sync_enable` enables SSL syncing mode, and `ssl_sync_interval` sets up the interval to check the last modified time of files configured with `proxy_ssl_certificate` and `proxy_ssl_certificate_key`. When a worker process initializes it creates ngx timer per server config section and the timer handler checks the `mtime` of the files. If there's any change it then sets a flag in the proxy server config that it needs to re-read the certificates.
So the _next time_ when it inits a new SSL connection to an upstream, it will check the flag, if syncing is needed it will then re-read the certificate and certificate key files and update it's `ssl->ctx`.